### PR TITLE
Basic vote

### DIFF
--- a/contracts/LiquidDemocracy.sol
+++ b/contracts/LiquidDemocracy.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.4.4;
 contract LiquidDemocracy {
 
     // This is the type for a single option shown in a ballot
-    struct Proposal {
+    struct BallotOption {
         bytes32 name; // short name (up to 32 bytes)
         uint voteCount; // number of accumulated votes
     }
     
-    // Keep array populated with binary, yes/no, options for simplicity
-    Proposal[] public proposals;
+    // Array is always populated with binary, yes/no, options for simplicity
+    BallotOption[] public ballot;
 
     // This is the type for a single voter metadata
     struct Voter {
@@ -22,10 +22,10 @@ contract LiquidDemocracy {
 
     // TODO - some kind of mapping for delegations 
 
-    function LiquidDemocracy(bytes32[] proposalNames) public {
-        for (uint i = 0; i < proposalNames.length; i++) {
-            proposals.push(Proposal({
-                name: proposalNames[i],
+    function LiquidDemocracy(bytes32[] ballotInstance) public {
+        for (uint i = 0; i < ballotInstance.length; i++) {
+            ballot.push(BallotOption({
+                name: ballotInstance[i],
                 voteCount: 0
             }));
         }

--- a/contracts/LiquidDemocracy.sol
+++ b/contracts/LiquidDemocracy.sol
@@ -42,7 +42,7 @@ contract LiquidDemocracy {
     * @notice Getter for ballot option vote count
     * @param ballotOption The desired option to read vote count from
     */
-    function getBallotVoteCount(uint ballotOption) public constant returns (uint voteCount) {
+    function getBallotVoteCount(uint ballotOption) public view returns (uint voteCount) {
         return ballot[ballotOption].voteCount;
     }
 
@@ -65,8 +65,8 @@ contract LiquidDemocracy {
     */
     function vote(address voter, uint voteOption) public {
         // Cannot vote more than once and must be registered
-        require(votersData[voter].registered == true);
-        require(votersData[voter].voted != true);
+        require(votersData[voter].registered);
+        require(!votersData[voter].voted);
         
         votersData[voter].voted = true;
         

--- a/contracts/LiquidDemocracy.sol
+++ b/contracts/LiquidDemocracy.sol
@@ -19,8 +19,8 @@ contract LiquidDemocracy {
     mapping(address => Voter) votersData;
 
     function LiquidDemocracy() public {
-        // For simplicity, ballot is always populated with only two option in this binary model
-        for (uint i = 0; i < 1; i++) {
+        // For simplicity, ballot is binary only
+        for (uint i = 0; i < 2; i++) {
             ballot.push(BallotOption({
                 voteCount: 0
             }));
@@ -59,9 +59,9 @@ contract LiquidDemocracy {
     }
 
     /**
-    * @notice TODO
-    * @param voter TODO
-    * @param voteOption TODO
+    * @notice Record a vote in the ballot
+    * @param voter The address of the voter
+    * @param voteOption The integer option chosen by voter
     */
     function vote(address voter, uint voteOption) public {
         // Cannot vote more than once and must be registered

--- a/contracts/LiquidDemocracy.sol
+++ b/contracts/LiquidDemocracy.sol
@@ -43,7 +43,7 @@ contract LiquidDemocracy {
     }
     
     /**
-    * @notice Getter for proposals length
+    * @notice Getter for ballot length
     */
     function getBallotLength() public constant returns(uint length) {
         return ballot.length;
@@ -51,18 +51,18 @@ contract LiquidDemocracy {
 
     /**
     * @notice Getter for ballot option name
-    * @param proposal The desired proposal option
+    * @param ballotOption The desired option to get name from
     */
-    function getBallotName(uint proposal) public constant returns (bytes32 name) {
-        return ballot[proposal].name;
+    function getBallotName(uint ballotOption) public constant returns (bytes32 name) {
+        return ballot[ballotOption].name;
     }
 
     /**
     * @notice Getter for ballot option vote count
-    * @param proposal The desired proposal option
+    * @param ballotOption The desired option to read vote count from
     */
-    function getBallotVoteCount(uint proposal) public constant returns (uint voteCount) {
-        return ballot[proposal].voteCount;
+    function getBallotVoteCount(uint ballotOption) public constant returns (uint voteCount) {
+        return ballot[ballotOption].voteCount;
     }
 
     /**
@@ -83,6 +83,7 @@ contract LiquidDemocracy {
     * @param voteOption TODO
     */
     function vote(address voter, uint voteOption) public {
+        // Cannot vote more than once and must be registered
         require(votersData[voter].registered == true);
         require(votersData[voter].voted != true);
         

--- a/contracts/LiquidDemocracy.sol
+++ b/contracts/LiquidDemocracy.sol
@@ -20,7 +20,7 @@ contract LiquidDemocracy {
     
     mapping(address => Voter) votersData;
 
-    // TODO - some kind of mapping for delegations 
+    // TODO - some kind of mapping for delegations
 
     function LiquidDemocracy(bytes32[] ballotInstance) public {
         for (uint i = 0; i < ballotInstance.length; i++) {
@@ -31,7 +31,6 @@ contract LiquidDemocracy {
         }
     }
 
-    // TODO - vote()
     // TODO - delegate()
     // TODO - revoke()
     
@@ -44,6 +43,29 @@ contract LiquidDemocracy {
     }
     
     /**
+    * @notice Getter for proposals length
+    */
+    function getBallotLength() public constant returns(uint length) {
+        return ballot.length;
+    }
+
+    /**
+    * @notice Getter for ballot option name
+    * @param proposal The desired proposal option
+    */
+    function getBallotName(uint proposal) public constant returns (bytes32 name) {
+        return ballot[proposal].name;
+    }
+
+    /**
+    * @notice Getter for ballot option vote count
+    * @param proposal The desired proposal option
+    */
+    function getBallotVoteCount(uint proposal) public constant returns (uint voteCount) {
+        return ballot[proposal].voteCount;
+    }
+
+    /**
     * @notice Register a new voter setting initial Voter elements
     */
     function registerNewVoter() public {
@@ -53,5 +75,22 @@ contract LiquidDemocracy {
 
         votersData[voterAddress].weight = 1;
         votersData[voterAddress].registered = true;
+    }
+
+    /**
+    * @notice TODO
+    * @param voter TODO
+    * @param voteOption TODO
+    */
+    function vote(address voter, uint voteOption) public {
+        require(votersData[voter].registered == true);
+        require(votersData[voter].voted != true);
+        
+        votersData[voter].voted = true;
+        
+        uint weight = votersData[voter].weight;
+
+        // Record vote for specific options
+        ballot[voteOption].voteCount += weight;
     }
 }

--- a/contracts/LiquidDemocracy.sol
+++ b/contracts/LiquidDemocracy.sol
@@ -4,11 +4,9 @@ contract LiquidDemocracy {
 
     // This is the type for a single option shown in a ballot
     struct BallotOption {
-        bytes32 name; // short name (up to 32 bytes)
         uint voteCount; // number of accumulated votes
     }
     
-    // Array is always populated with binary, yes/no, options for simplicity
     BallotOption[] public ballot;
 
     // This is the type for a single voter metadata
@@ -20,12 +18,10 @@ contract LiquidDemocracy {
     
     mapping(address => Voter) votersData;
 
-    // TODO - some kind of mapping for delegations
-
-    function LiquidDemocracy(bytes32[] ballotInstance) public {
-        for (uint i = 0; i < ballotInstance.length; i++) {
+    function LiquidDemocracy() public {
+        // For simplicity, ballot is always populated with only two option in this binary model
+        for (uint i = 0; i < 1; i++) {
             ballot.push(BallotOption({
-                name: ballotInstance[i],
                 voteCount: 0
             }));
         }
@@ -40,21 +36,6 @@ contract LiquidDemocracy {
     */
     function getVoterData(address voter) public view returns (uint, bool, bool) {
         return (votersData[voter].weight, votersData[voter].registered, votersData[voter].voted);
-    }
-    
-    /**
-    * @notice Getter for ballot length
-    */
-    function getBallotLength() public constant returns(uint length) {
-        return ballot.length;
-    }
-
-    /**
-    * @notice Getter for ballot option name
-    * @param ballotOption The desired option to get name from
-    */
-    function getBallotName(uint ballotOption) public constant returns (bytes32 name) {
-        return ballot[ballotOption].name;
     }
 
     /**

--- a/test/LiquidDemocracy.test.js
+++ b/test/LiquidDemocracy.test.js
@@ -7,50 +7,26 @@ const should = require('chai')
   .should();
 
 contract('LiquidDemocracy', function (accounts){
-    const ballot = ['yes', 'no'];
-    
-    describe('setting up liquid democracy', function () {
-      // this could be beforeEach
-      it('should create liquid democracy instance with provided ballot', async function () {
-        this.liquidDemocracyBallot = await LiquidDemocracy.new(ballot);
-        should.exist(this.liquidDemocracyBallot);
-      });
-      
-      it('should register new voters', async function () {
-        this.liquidDemocracyBallot = await LiquidDemocracy.new(ballot);
-        
-        await this.liquidDemocracyBallot.registerNewVoter({ from: accounts[0] });
-        const voter0 = await this.liquidDemocracyBallot.getVoterData(accounts[0]);
-        await this.liquidDemocracyBallot.registerNewVoter({ from: accounts[1] });
-        const voter1 = await this.liquidDemocracyBallot.getVoterData(accounts[1]);
-        await this.liquidDemocracyBallot.registerNewVoter({ from: accounts[2] });
-        const voter2 = await this.liquidDemocracyBallot.getVoterData(accounts[2]);
-        await this.liquidDemocracyBallot.registerNewVoter({ from: accounts[3] });
-        const voter3 = await this.liquidDemocracyBallot.getVoterData(accounts[3]);
-        
-        should.exist(voter0);
-        should.exist(voter1);
-        should.exist(voter2);
-        should.exist(voter3);
-        // console.log(voter0);
-        // console.log(voter1);
-      });
 
-      it('should allow voters to vote', async function () {
-        // console.log(voter0);
-        this.liquidDemocracyBallot = await LiquidDemocracy.new(ballot);
-        
-        await this.liquidDemocracyBallot.registerNewVoter({ from: accounts[0] });
+  beforeEach(async function () {
+    // Set up ballot instance and register 4 voters
+    this.liquidDemocracyBallot = await LiquidDemocracy.new();
+    for (let i = 0; i < 4; i++) {
+      await this.liquidDemocracyBallot.registerNewVoter({ from: accounts[i] });
+    }
+  });
+  
+  it('should register voters successfully', async function () {
+    const registered = await this.liquidDemocracyBallot.getVoterData(accounts[0]);
+    let registeredWeight = registered[0].toString();
+    let registeredStatus = registered[1];
+    const unregistered = await this.liquidDemocracyBallot.getVoterData(accounts[4]);
+    let unregisteredWeight = unregistered[0].toString();
+    let unregisteredStatus = unregistered[1];
 
-        await this.liquidDemocracyBallot.vote(accounts[0], 0);
-
-        const voteCount = await this.liquidDemocracyBallot.getBallotVoteCount(0);
-        console.log(voteCount);
-
-        // TODO - should refactor to use beforeEach, 
-        // the setup should be taken care there,
-        // basically create ballot and register voters
-      });
-      
-    });
+    registeredWeight.should.equal('1');
+    registeredStatus.should.equal(true);
+    unregisteredWeight.should.equal('0');
+    unregisteredStatus.should.equal(false);
+  });  
 });

--- a/test/LiquidDemocracy.test.js
+++ b/test/LiquidDemocracy.test.js
@@ -1,3 +1,5 @@
+import assertRevert from './helpers/assertRevert';
+
 const LiquidDemocracy = artifacts.require('LiquidDemocracy');
 
 const BigNumber = web3.BigNumber;
@@ -16,17 +18,45 @@ contract('LiquidDemocracy', function (accounts){
     }
   });
   
-  it('should register voters successfully', async function () {
-    const registered = await this.liquidDemocracyBallot.getVoterData(accounts[0]);
-    let registeredWeight = registered[0].toString();
-    let registeredStatus = registered[1];
-    const unregistered = await this.liquidDemocracyBallot.getVoterData(accounts[4]);
-    let unregisteredWeight = unregistered[0].toString();
-    let unregisteredStatus = unregistered[1];
+  describe('registration set up', function () {
+    it('should register voters successfully', async function () {
+      const registered = await this.liquidDemocracyBallot.getVoterData(accounts[0]);
+      let registeredWeight = registered[0].toString();
+      let registeredStatus = registered[1];
+      const unregistered = await this.liquidDemocracyBallot.getVoterData(accounts[4]);
+      let unregisteredWeight = unregistered[0].toString();
+      let unregisteredStatus = unregistered[1];
+  
+      registeredWeight.should.equal('1');
+      registeredStatus.should.equal(true);
+      unregisteredWeight.should.equal('0');
+      unregisteredStatus.should.equal(false);
+    });
+  });
+  
+  describe('voting', function () {
+    it('should allow registered voters to vote', async function () {
+      await this.liquidDemocracyBallot.vote(accounts[0], 0);
+      await this.liquidDemocracyBallot.vote(accounts[1], 0);
+      await this.liquidDemocracyBallot.vote(accounts[2], 1);
+      const voteCountOption0 = await this.liquidDemocracyBallot.getBallotVoteCount(0);
+      const voteCountOption1 = await this.liquidDemocracyBallot.getBallotVoteCount(1);
 
-    registeredWeight.should.equal('1');
-    registeredStatus.should.equal(true);
-    unregisteredWeight.should.equal('0');
-    unregisteredStatus.should.equal(false);
-  });  
+      voteCountOption0.toNumber().should.equal(2);
+      voteCountOption1.toNumber().should.equal(1);
+    });
+
+    it('should not allow unregistered voters to vote', async function () {
+      await assertRevert(this.liquidDemocracyBallot.vote(accounts[4], 0));
+    });
+
+    it('should not allow registered voters to vote more than once', async function () {
+      await this.liquidDemocracyBallot.vote(accounts[0], 0);
+      await assertRevert(this.liquidDemocracyBallot.vote(accounts[0], 0));
+    });
+  });
+
+  describe('delegating', function () {
+    // TODO
+  });
 });

--- a/test/LiquidDemocracy.test.js
+++ b/test/LiquidDemocracy.test.js
@@ -7,16 +7,17 @@ const should = require('chai')
   .should();
 
 contract('LiquidDemocracy', function (accounts){
-    var proposals = ['yes', 'no'];
+    const ballot = ['yes', 'no'];
     
     describe('setting up liquid democracy', function () {
-      it('should create ballot instance with provided proposals', async function () {
-        this.liquidDemocracyBallot = await LiquidDemocracy.new(proposals);
+      // this could be beforeEach
+      it('should create liquid democracy instance with provided ballot', async function () {
+        this.liquidDemocracyBallot = await LiquidDemocracy.new(ballot);
         should.exist(this.liquidDemocracyBallot);
       });
       
       it('should register new voters', async function () {
-        this.liquidDemocracyBallot = await LiquidDemocracy.new(proposals);
+        this.liquidDemocracyBallot = await LiquidDemocracy.new(ballot);
         await this.liquidDemocracyBallot.registerNewVoter({ from: accounts[0] });
         const voter1 = await this.liquidDemocracyBallot.getVoterData(accounts[0]);
         should.exist(voter1);

--- a/test/LiquidDemocracy.test.js
+++ b/test/LiquidDemocracy.test.js
@@ -18,9 +18,38 @@ contract('LiquidDemocracy', function (accounts){
       
       it('should register new voters', async function () {
         this.liquidDemocracyBallot = await LiquidDemocracy.new(ballot);
+        
         await this.liquidDemocracyBallot.registerNewVoter({ from: accounts[0] });
-        const voter1 = await this.liquidDemocracyBallot.getVoterData(accounts[0]);
+        const voter0 = await this.liquidDemocracyBallot.getVoterData(accounts[0]);
+        await this.liquidDemocracyBallot.registerNewVoter({ from: accounts[1] });
+        const voter1 = await this.liquidDemocracyBallot.getVoterData(accounts[1]);
+        await this.liquidDemocracyBallot.registerNewVoter({ from: accounts[2] });
+        const voter2 = await this.liquidDemocracyBallot.getVoterData(accounts[2]);
+        await this.liquidDemocracyBallot.registerNewVoter({ from: accounts[3] });
+        const voter3 = await this.liquidDemocracyBallot.getVoterData(accounts[3]);
+        
+        should.exist(voter0);
         should.exist(voter1);
+        should.exist(voter2);
+        should.exist(voter3);
+        // console.log(voter0);
+        // console.log(voter1);
+      });
+
+      it('should allow voters to vote', async function () {
+        // console.log(voter0);
+        this.liquidDemocracyBallot = await LiquidDemocracy.new(ballot);
+        
+        await this.liquidDemocracyBallot.registerNewVoter({ from: accounts[0] });
+
+        await this.liquidDemocracyBallot.vote(accounts[0], 0);
+
+        const voteCount = await this.liquidDemocracyBallot.getBallotVoteCount(0);
+        console.log(voteCount);
+
+        // TODO - should refactor to use beforeEach, 
+        // the setup should be taken care there,
+        // basically create ballot and register voters
       });
       
     });

--- a/test/helpers/assertRevert.js
+++ b/test/helpers/assertRevert.js
@@ -1,0 +1,10 @@
+export default async promise => {
+    try {
+      await promise;
+      assert.fail('Expected revert not received');
+    } catch (error) {
+      const revertFound = error.message.search('revert') >= 0;
+      assert(revertFound, `Expected "revert", got ${error} instead`);
+    }
+  };
+  


### PR DESCRIPTION
@aecc note I abstracted and simplified the ballot (0f294025b368097e1b0f6ebf7a6ce79992ee745c) by removing string array like we talked about. 

Also I refactored `LiquidDemocracy.test.js` to make use of `beforeEach()`. This is the kind of readability I think we should aim for. 

Creating this PR now because it might make sense to merge this first before merging `delegate()` functionality.

Closes #11 