### PR TITLE
Fix `describe` scopes

### DIFF
--- a/test/LiquidDemocracy.test.js
+++ b/test/LiquidDemocracy.test.js
@@ -208,6 +208,8 @@ contract('LiquidDemocracy', function (accounts){
             }
         });
 
+    });
+
     describe('removes votes', function () {
 
         it('removes a voters vote', async function () {
@@ -228,9 +230,7 @@ contract('LiquidDemocracy', function (accounts){
             votedOption2.should.equal(false);
             count.toNumber().should.equal(0);
         });
-
-    });
-
+        
     });
 
 });


### PR DESCRIPTION
Notice the `describe('removes votes')` was within the scope of `describe('returns voters data')`. 

Most likely a mistake but PR'ing instead of directly committing just in case.