### PR TITLE
Update version pragma

### DIFF
--- a/contracts/LiquidDemocracy.sol
+++ b/contracts/LiquidDemocracy.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.23;
+pragma solidity 0.4.18;
 
 
 contract LiquidDemocracy {


### PR DESCRIPTION
With `pragma solidity 0.4.23` I'm seeing `LiquidDemocracy.sol` fails to compile with the following message: 

```sh
../democracyearth/dapp/contracts/LiquidDemocracy.sol:1:1: SyntaxError: Source file requires different compiler version (current compiler is 0.4.18+commit.9cf6e910.Emscripten.clang..)
```

Anyone else seeing this? Updating to `0.4.18` lets me compile and test without an issue.